### PR TITLE
Erase aligned writes

### DIFF
--- a/TESTS/COMMON/test_setup.h
+++ b/TESTS/COMMON/test_setup.h
@@ -13,6 +13,11 @@ SimulatorBlockDevice bd("lorawan-frag-in-flash", 256 * 528, static_cast<uint64_t
 #include "AT45BlockDevice.h"
 AT45BlockDevice bd(SPI_MOSI, SPI_MISO, SPI_SCK, SPI_NSS);
 
+#elif defined(TARGET_DISCO_L475VG_IOT01A)
+// Flash interface on the DISCO-L475VG board
+#include "QSPIFBlockDevice.h"
+QSPIFBlockDevice bd (QSPI_FLASH1_IO0, QSPI_FLASH1_IO1, QSPI_FLASH1_IO2, QSPI_FLASH1_IO3, QSPI_FLASH1_SCK, QSPI_FLASH1_CSN, QSPIF_POLARITY_MODE_0, MBED_CONF_QSPIF_QSPI_FREQ);
+
 #else
 #error "No storage selected in test_setup.h"
 

--- a/TESTS/tests/mbed_app.json
+++ b/TESTS/tests/mbed_app.json
@@ -76,7 +76,6 @@
             "lorawan-update-client.slot2-fw-address"    : "(0x201000 + 72)",
             "lorawan-update-client.internal-flash-header": "(0x08000000 + (34 * 1024))",
             "lorawan-update-client.overwrite-version"   : false,
-            "lorawan-update-client.bd-page-size"        : "0x1000",
             "target.app_offset"                         : "0x9000",
             "target.header_offset"                      : "0x8800"
         }

--- a/TESTS/tests/mbed_app.json
+++ b/TESTS/tests/mbed_app.json
@@ -62,6 +62,23 @@
             "lorawan-update-client.overwrite-version"   : false,
             "target.app_offset"                         : "0x8400",
             "target.header_offset"                      : "0x8000"
+        },
+        "DISCO_L475VG_IOT01A": {
+            "target.features_add"                       : ["BOOTLOADER"],
+            "target.components_add"                     : ["QSPIF"],
+            "lorawan-update-client.max-redundancy"      : "40",
+            "lorawan-update-client.slot-size"           : "0x10000",
+            "lorawan-update-client.slot0-header-address": "0x1000",
+            "lorawan-update-client.slot0-fw-address"    : "(0x1000 + 296)",
+            "lorawan-update-client.slot1-header-address": "0x101000",
+            "lorawan-update-client.slot1-fw-address"    : "(0x101000 + 296)",
+            "lorawan-update-client.slot2-header-address": "0x201000",
+            "lorawan-update-client.slot2-fw-address"    : "(0x201000 + 72)",
+            "lorawan-update-client.internal-flash-header": "(0x08000000 + (34 * 1024))",
+            "lorawan-update-client.overwrite-version"   : false,
+            "lorawan-update-client.bd-page-size"        : "0x1000",
+            "target.app_offset"                         : "0x9000",
+            "target.header_offset"                      : "0x8800"
         }
     },
     "macros": [

--- a/fragmentation/source/FragmentationBlockDeviceWrapper.cpp
+++ b/fragmentation/source/FragmentationBlockDeviceWrapper.cpp
@@ -36,7 +36,7 @@ int FragmentationBlockDeviceWrapper::init() {
         return init_ret;
     }
 
-    _page_size = _block_device->get_read_size();
+    _page_size = _block_device->get_erase_size();
     _total_size = _block_device->size();
 
     void *buffer = calloc((size_t)_page_size, 1);
@@ -90,6 +90,10 @@ int FragmentationBlockDeviceWrapper::program(const void *a_buffer, bd_addr_t add
             // frag_debug("%02x ", _page_buffer[ix]);
         // }
         // frag_debug("\n");
+
+        // erase the block first
+        r = _block_device->erase(page * _page_size, _page_size);
+        if (r != 0) return r;
 
         // and write back
         r = _block_device->program(_page_buffer, page * _page_size, _page_size);


### PR DESCRIPTION
This enables the update client on QSPI devices such as DISCO L475VG.